### PR TITLE
[fix] Force couchbase version to one prior 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/IndigoUnited/node-couchnode",
   "dependencies": {
     "async": "^0.9.0",
-    "couchbase": "^2.0.2",
+    "couchbase": "~2.0.12",
     "coveralls": "^2.11.2",
     "mocha-lcov-reporter": "0.0.2"
   },


### PR DESCRIPTION
Couchbase 2.1.x seems to have some memory leak issues
stick to healthy version
