### PR TITLE
Set couchbase as a peer dependency. closes #4

### DIFF
--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -124,10 +124,7 @@ function _array(x) {
 
 function _applyCasToOptions(opt, cas, key) {
     // TODO: consider improving the check below. Sucks that I have to do Object.keys just to check if it's not an empty object
-    // if (cas[key] && typeof cas[key] === 'object' && Object.keys(cas[key]).length) {
-    // Instead relying on my knowledge of what a valid CAS is, but considering this object is
-    // opaque, it might change in future... Going for performance for now.
-    if (cas[key] && typeof cas[key] === 'object' && cas[key].hasOwnProperty('0') && cas[key].hasOwnProperty('1')) {
+    if (cas[key] && typeof cas[key] === 'object' && Object.keys(cas[key]).length) {
         opt.cas = cas[key];
     } else {
         delete opt.cas;

--- a/package.json
+++ b/package.json
@@ -31,15 +31,18 @@
   },
   "homepage": "https://github.com/IndigoUnited/node-couchnode",
   "dependencies": {
-    "async": "^0.9.0",
-    "couchbase": "~2.0.12"
+    "async": "^0.9.0"
   },
   "devDependencies": {
+    "codacy-coverage": "^1.1.2",
+    "couchbase": "^2.1.2",
+    "coveralls": "^2.11.2",
     "expect.js": "^0.3.1",
     "istanbul": "^0.3.2",
     "mocha": "^2.2.4",
-    "codacy-coverage": "^1.1.2",
-    "coveralls": "^2.11.2",
     "mocha-lcov-reporter": "0.0.2"
+  },
+  "peerDependencies": {
+    "couchbase": "^2.1.2"
   }
 }

--- a/test/lib/suites/misc.js
+++ b/test/lib/suites/misc.js
@@ -19,12 +19,12 @@ module.exports  = function () {
         var initialMaxReadsPerOp  = bucket.maxReadsPerOp;
         var initialMaxWritesPerOp = bucket.maxWritesPerOp;
 
-        bucket.maxReadsPerOp  = 25000;
-        bucket.maxWritesPerOp = 5000;
+        bucket.maxReadsPerOp  = 2500;
+        bucket.maxWritesPerOp = 500;
 
         var tuples = {};
 
-        for (var i = 1; i <= 200000; i++) {
+        for (var i = 1; i <= 20000; i++) {
             tuples['key' + i] = 'foo';
         }
 


### PR DESCRIPTION
Closes #4 
[upd] Bump couchbase to 2.1.2
We still keep it on devDependencies, since the tests actually use the module.

[fix] Cas object structure has indeed changed
[upd] Reduce the number of operations in the test 'should limit the amount of parallel read & write ops'.
